### PR TITLE
Implement RESP2 Serialization

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2024 Obakeng Mosadi mosadiobakeng7@gmail.com
-
 */
 package cmd
 
@@ -10,21 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "redis-server",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Short: "In-memory data structure server",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -37,15 +25,5 @@ func Execute() {
 }
 
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.redis-server.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// Nothing to add here right now
 }
-
-

--- a/pkg/deserializer.go
+++ b/pkg/deserializer.go
@@ -36,5 +36,85 @@ func DeserializeBulkStrings(value string) string {
 }
 
 func DeserializeArrays(value string) interface{} {
-	return []string{"1"}
+	lines := strings.Split(value, CRLF)
+	if len(lines) < 2 {
+		return nil
+	}
+
+	if !strings.HasPrefix(lines[0], ARRAY_PREFIX) {
+		return nil
+	}
+
+	arrayLength, err := strconv.Atoi(strings.TrimPrefix(lines[0], ARRAY_PREFIX))
+	if err != nil {
+		return nil
+	}
+
+	var result []interface{}
+	index := 1
+
+	for i := 0; i < arrayLength; i++ {
+		if index >= len(lines) {
+			return nil
+		}
+
+		switch {
+		case strings.HasPrefix(lines[index], INT_PREFIX):
+			intVal, err := strconv.Atoi(strings.TrimPrefix(lines[index], INT_PREFIX))
+			if err != nil {
+				return nil
+			}
+			result = append(result, intVal)
+			index++
+
+		case strings.HasPrefix(lines[index], BULK_STRING_PREFIX):
+			length, err := strconv.Atoi(strings.TrimPrefix(lines[index], BULK_STRING_PREFIX))
+			if err != nil || index+1 >= len(lines) {
+				return nil
+			}
+			strVal := lines[index+1]
+			if len(strVal) != length {
+				return nil
+			}
+			result = append(result, strVal)
+			index += 2
+
+		default:
+			return nil
+		}
+	}
+
+	if allInts(result) {
+		var intResult []int
+		for _, v := range result {
+			intResult = append(intResult, v.(int))
+		}
+		return intResult
+	} else if allStrings(result) {
+		var stringResult []string
+		for _, v := range result {
+			stringResult = append(stringResult, v.(string))
+		}
+		return stringResult
+	}
+
+	return result
+}
+
+func allInts(arr []interface{}) bool {
+	for _, v := range arr {
+		if _, ok := v.(int); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func allStrings(arr []interface{}) bool {
+	for _, v := range arr {
+		if _, ok := v.(string); !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/deserializer.go
+++ b/pkg/deserializer.go
@@ -1,0 +1,5 @@
+package pkg
+
+func DeserializeSimpleStrings(value string) string {
+	return "OK"
+}

--- a/pkg/deserializer.go
+++ b/pkg/deserializer.go
@@ -1,5 +1,40 @@
 package pkg
 
+import (
+	"strconv"
+	"strings"
+)
+
 func DeserializeSimpleStrings(value string) string {
-	return "OK"
+	value = strings.TrimPrefix(value, SIMPLE_STRING_PREFIX)
+	value = strings.TrimSuffix(value, CRLF)
+
+	return value
+}
+
+func DeserializeErrors(value string) string {
+	value = strings.TrimPrefix(value, ERROR_PREFIX)
+	value = strings.TrimSuffix(value, CRLF)
+
+	return value
+}
+
+func DeserializeIntegers(value string) int {
+	value = strings.TrimPrefix(value, INT_PREFIX)
+	value = strings.TrimSuffix(value, CRLF)
+
+	convertedValue, _ := strconv.Atoi(value)
+
+	return convertedValue
+}
+
+func DeserializeBulkStrings(value string) string {
+	value = strings.TrimPrefix(value, BULK_STRING_PREFIX)
+	value = strings.TrimSuffix(value, CRLF)
+
+	return value[3:] // removes the length in the final string (the number after $)
+}
+
+func DeserializeArrays(value string) interface{} {
+	return []string{"1"}
 }

--- a/pkg/deserializer_test.go
+++ b/pkg/deserializer_test.go
@@ -1,6 +1,7 @@
 package pkg_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/obakeng-develops/redis-server/pkg"
@@ -30,6 +31,117 @@ func TestDeserializeSimplesStrings(t *testing.T) {
 
 			if result != tc.expected {
 				t.Errorf("got %s, want %s", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDeserializeErrors(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "returns unknown command",
+			input:       "-unknown command\r\n",
+			expected:    "unknown command",
+		},
+		{
+			description: "returns operation against wrong type",
+			input:       "-operation against wrong type\r\n",
+			expected:    "operation against wrong type",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.DeserializeErrors(tc.input)
+
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDeserializeIntegers(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    int
+	}{
+		{
+			description: "returns 100",
+			input:       ":100\r\n",
+			expected:    100,
+		},
+		{
+			description: "returns 10",
+			input:       ":10\r\n",
+			expected:    10,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.DeserializeIntegers(tc.input)
+
+			if result != tc.expected {
+				t.Errorf("got %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDeserializeBulkStrings(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "returns hello",
+			input:       "$5\r\nhello\r\n",
+			expected:    "hello",
+		},
+		{
+			description: "returns 10",
+			input:       "$0\r\n\r\n",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.DeserializeBulkStrings(tc.input)
+
+			if result != tc.expected {
+				t.Errorf("got %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDeserializeArrays(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    interface{}
+	}{
+		{
+			description: "returns 3 integer arrary",
+			input:       "*3\r\n:1\r\n:2\r\n:3\r\n",
+			expected:    []int{1, 2, 3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.DeserializeArrays(tc.input)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("got %v, want %v", result, tc.expected)
 			}
 		})
 	}

--- a/pkg/deserializer_test.go
+++ b/pkg/deserializer_test.go
@@ -134,6 +134,11 @@ func TestDeserializeArrays(t *testing.T) {
 			input:       "*3\r\n:1\r\n:2\r\n:3\r\n",
 			expected:    []int{1, 2, 3},
 		},
+		{
+			description: "returns hello world",
+			input:       "*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n",
+			expected:    []string{"hello", "world"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/deserializer_test.go
+++ b/pkg/deserializer_test.go
@@ -1,0 +1,36 @@
+package pkg_test
+
+import (
+	"testing"
+
+	"github.com/obakeng-develops/redis-server/pkg"
+)
+
+func TestDeserializeSimplesStrings(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "returns OK",
+			input:       "+OK\r\n",
+			expected:    "OK",
+		},
+		{
+			description: "returns PONG",
+			input:       "+PONG\r\n",
+			expected:    "PONG",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.DeserializeSimpleStrings(tc.input)
+
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/serializer.go
+++ b/pkg/serializer.go
@@ -67,6 +67,26 @@ func SerializeArrays(s interface{}) string {
 		}
 
 		return finalArray
+	case []interface{}:
+		arrayLength := len(values)
+		finalArray := ARRAY_PREFIX + strconv.Itoa(arrayLength) + CRLF
+
+		if arrayLength == 0 {
+			return emptyArray
+		}
+
+		for _, value := range values {
+			switch v := value.(type) {
+			case int:
+				finalArray += INT_PREFIX + strconv.Itoa(v) + CRLF
+			case string:
+				finalArray += BULK_STRING_PREFIX + strconv.Itoa(len(v)) + CRLF + v + CRLF
+			default:
+				return ""
+			}
+		}
+
+		return finalArray
 	default:
 		return ""
 	}

--- a/pkg/serializer.go
+++ b/pkg/serializer.go
@@ -15,15 +15,15 @@ const (
 )
 
 func SerializeSimpleStrings(value string) string {
-	return SIMPLE_STRING_PREFIX + value + CRLF
+	return SIMPLE_STRING_PREFIX + value + CRLF // +OK\r\n
 }
 
 func SerializeErrors(value string) string {
-	return ERROR_PREFIX + value + CRLF
+	return ERROR_PREFIX + value + CRLF // -Nothing\r\n
 }
 
 func SerializeIntegers(value int) string {
-	return INT_PREFIX + strconv.Itoa(value) + CRLF
+	return INT_PREFIX + strconv.Itoa(value) + CRLF // :10\r\n
 }
 
 func SerializeBulkStrings(value string) string {
@@ -32,7 +32,7 @@ func SerializeBulkStrings(value string) string {
 		return emptyBulkString
 	}
 
-	return BULK_STRING_PREFIX + strconv.Itoa(len(value)) + CRLF + value + CRLF
+	return BULK_STRING_PREFIX + strconv.Itoa(len(value)) + CRLF + value + CRLF //$1\r\nhello\r\n
 }
 
 func SerializeArrays(s interface{}) string {

--- a/pkg/serializer.go
+++ b/pkg/serializer.go
@@ -68,7 +68,6 @@ func SerializeArrays(s interface{}) string {
 
 		return finalArray
 	default:
-		fmt.Println("Unsupported type")
 		return ""
 	}
 }

--- a/pkg/serializer.go
+++ b/pkg/serializer.go
@@ -1,27 +1,74 @@
 package pkg
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	CRLF                 = "\r\n"
+	SIMPLE_STRING_PREFIX = "+"
+	ERROR_PREFIX         = "-"
+	INT_PREFIX           = ":"
+	BULK_STRING_PREFIX   = "$"
+	ARRAY_PREFIX         = "*"
+)
 
 func SerializeSimpleStrings(value string) string {
-	return "+" + value + "\r\n"
+	return SIMPLE_STRING_PREFIX + value + CRLF
 }
 
 func SerializeErrors(value string) string {
-	return "-" + value + "\r\n"
+	return ERROR_PREFIX + value + CRLF
 }
 
 func SerializeIntegers(value int) string {
-	return ":" + strconv.Itoa(value) + "\r\n"
+	return INT_PREFIX + strconv.Itoa(value) + CRLF
 }
 
 func SerializeBulkStrings(value string) string {
 	if value == "" {
-		return "$-1\r\n"
+		emptyBulkString := BULK_STRING_PREFIX + "0" + CRLF + CRLF
+		return emptyBulkString
 	}
 
-	return "$" + strconv.Itoa(len(value)) + "\r\n" + value + "\r\n"
+	return BULK_STRING_PREFIX + strconv.Itoa(len(value)) + CRLF + value + CRLF
 }
 
-func SerializeArrays(values []string) string {
-	return "nil"
+func SerializeArrays(s interface{}) string {
+	emptyArray := ARRAY_PREFIX + "0" + CRLF
+
+	switch values := s.(type) {
+	case []string:
+		arrayLength := len(values)
+		finalArray := ARRAY_PREFIX + strconv.Itoa(arrayLength) + CRLF
+
+		if arrayLength == 0 {
+			return emptyArray
+		}
+
+		for _, value := range values {
+			str := fmt.Sprintf("%v", value)
+			finalArray += BULK_STRING_PREFIX + strconv.Itoa(len(str)) + CRLF + str + CRLF
+		}
+
+		return finalArray
+	case []int:
+		arrayLength := len(values)
+		finalArray := ARRAY_PREFIX + strconv.Itoa(arrayLength) + CRLF
+
+		if arrayLength == 0 {
+			return emptyArray
+		}
+
+		for _, value := range values {
+			str := fmt.Sprintf("%v", value)
+			finalArray += INT_PREFIX + str + CRLF
+		}
+
+		return finalArray
+	default:
+		fmt.Println("Unsupported type")
+		return ""
+	}
 }

--- a/pkg/serializer.go
+++ b/pkg/serializer.go
@@ -1,0 +1,27 @@
+package pkg
+
+import "strconv"
+
+func SerializeSimpleStrings(value string) string {
+	return "+" + value + "\r\n"
+}
+
+func SerializeErrors(value string) string {
+	return "-" + value + "\r\n"
+}
+
+func SerializeIntegers(value int) string {
+	return ":" + strconv.Itoa(value) + "\r\n"
+}
+
+func SerializeBulkStrings(value string) string {
+	if value == "" {
+		return "$-1\r\n"
+	}
+
+	return "$" + strconv.Itoa(len(value)) + "\r\n" + value + "\r\n"
+}
+
+func SerializeArrays(values []string) string {
+	return "nil"
+}

--- a/pkg/serializer_test.go
+++ b/pkg/serializer_test.go
@@ -1,0 +1,89 @@
+package pkg_test
+
+import (
+	"testing"
+
+	"github.com/obakeng-develops/redis-server/pkg"
+)
+
+func TestSimpleStrings(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			"returns hello world",
+			"hello world",
+			"+hello world\r\n",
+		},
+		{
+			"returns OK",
+			"OK",
+			"+OK\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := pkg.SerializeSimpleStrings(tt.input)
+
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", tt.input, tt.expected)
+			}
+		})
+	}
+}
+
+func TestErrors(t *testing.T) {
+	tests := []struct {
+		description string
+		input       int
+		expected    string
+	}{
+		{
+			"returns 10",
+			10,
+			":10\r\n",
+		},
+		{
+			"returns 100",
+			100,
+			":100\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := pkg.SerializeIntegers(tt.input)
+
+			if result != tt.expected {
+				t.Errorf("got %d, want %s", tt.input, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBulkStrings(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			"returns nil",
+			"",
+			"$-1\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := pkg.SerializeBulkStrings(tt.input)
+
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", tt.input, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/serializer_test.go
+++ b/pkg/serializer_test.go
@@ -13,14 +13,14 @@ func TestSimpleStrings(t *testing.T) {
 		expected    string
 	}{
 		{
-			"returns hello world",
-			"hello world",
-			"+hello world\r\n",
+			description: "returns hello world",
+			input:       "hello world",
+			expected:    "+hello world\r\n",
 		},
 		{
-			"returns OK",
-			"OK",
-			"+OK\r\n",
+			description: "returns OK",
+			input:       "OK",
+			expected:    "+OK\r\n",
 		},
 	}
 
@@ -29,7 +29,7 @@ func TestSimpleStrings(t *testing.T) {
 			result := pkg.SerializeSimpleStrings(tt.input)
 
 			if result != tt.expected {
-				t.Errorf("got %s, want %s", tt.input, tt.expected)
+				t.Errorf("got %s, want %s", result, tt.expected)
 			}
 		})
 	}
@@ -42,14 +42,14 @@ func TestErrors(t *testing.T) {
 		expected    string
 	}{
 		{
-			"returns 10",
-			10,
-			":10\r\n",
+			description: "returns 10",
+			input:       10,
+			expected:    ":10\r\n",
 		},
 		{
-			"returns 100",
-			100,
-			":100\r\n",
+			description: "returns 100",
+			input:       100,
+			expected:    ":100\r\n",
 		},
 	}
 
@@ -58,7 +58,7 @@ func TestErrors(t *testing.T) {
 			result := pkg.SerializeIntegers(tt.input)
 
 			if result != tt.expected {
-				t.Errorf("got %d, want %s", tt.input, tt.expected)
+				t.Errorf("got %s, want %s", result, tt.expected)
 			}
 		})
 	}
@@ -71,9 +71,14 @@ func TestBulkStrings(t *testing.T) {
 		expected    string
 	}{
 		{
-			"returns nil",
-			"",
-			"$-1\r\n",
+			description: "returns hello",
+			input:       "hello",
+			expected:    "$5\r\nhello\r\n",
+		},
+		{
+			description: "returns",
+			input:       "",
+			expected:    "$0\r\n\r\n",
 		},
 	}
 
@@ -82,7 +87,46 @@ func TestBulkStrings(t *testing.T) {
 			result := pkg.SerializeBulkStrings(tt.input)
 
 			if result != tt.expected {
-				t.Errorf("got %s, want %s", tt.input, tt.expected)
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestArrays(t *testing.T) {
+	tests := []struct {
+		description string
+		input       interface{}
+		expected    string
+	}{
+		{
+			description: "returns empty array",
+			input:       []string{},
+			expected:    "*0\r\n",
+		},
+		{
+			description: "returns 2 element array",
+			input:       []string{"hello", "world"},
+			expected:    "*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n",
+		},
+		{
+			description: "returns 3 integer array",
+			input:       []int{1, 2, 3},
+			expected:    "*3\r\n:1\r\n:2\r\n:3\r\n",
+		},
+		{
+			description: "returns unsupported type",
+			input:       map[string]int{"a": 1},
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := pkg.SerializeArrays(tt.input)
+
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
 			}
 		})
 	}

--- a/pkg/serializer_test.go
+++ b/pkg/serializer_test.go
@@ -13,14 +13,19 @@ func TestSimpleStrings(t *testing.T) {
 		expected    string
 	}{
 		{
-			description: "returns hello world",
-			input:       "hello world",
-			expected:    "+hello world\r\n",
+			description: "returns SUCCESS",
+			input:       "SUCCESS",
+			expected:    "+SUCCESS\r\n",
 		},
 		{
 			description: "returns OK",
 			input:       "OK",
 			expected:    "+OK\r\n",
+		},
+		{
+			description: "returns PONG",
+			input:       "PONG",
+			expected:    "+PONG\r\n",
 		},
 	}
 

--- a/pkg/serializer_test.go
+++ b/pkg/serializer_test.go
@@ -150,7 +150,7 @@ func TestArrays(t *testing.T) {
 		},
 		{
 			description: "returns mixed element array",
-			input:       []interface{}{1, "2", 3},
+			input:       []interface{}{1, 2, 3, 4, "hello"},
 			expected:    "*5\r\n:1\r\n:2\r\n:3\r\n:4\r\n$5\r\nhello\r\n",
 		},
 		{

--- a/pkg/serializer_test.go
+++ b/pkg/serializer_test.go
@@ -24,18 +24,18 @@ func TestSimpleStrings(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			result := pkg.SerializeSimpleStrings(tt.input)
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.SerializeSimpleStrings(tc.input)
 
-			if result != tt.expected {
-				t.Errorf("got %s, want %s", result, tt.expected)
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
 			}
 		})
 	}
 }
 
-func TestErrors(t *testing.T) {
+func TestIntegers(t *testing.T) {
 	tests := []struct {
 		description string
 		input       int
@@ -53,12 +53,41 @@ func TestErrors(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			result := pkg.SerializeIntegers(tt.input)
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.SerializeIntegers(tc.input)
 
-			if result != tt.expected {
-				t.Errorf("got %s, want %s", result, tt.expected)
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestErrors(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "returns unknown command",
+			input:       "unknown command",
+			expected:    "-unknown command\r\n",
+		},
+		{
+			description: "returns operation against wrong type",
+			input:       "operation against wrong type",
+			expected:    "-operation against wrong type\r\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.SerializeErrors(tc.input)
+
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
 			}
 		})
 	}
@@ -82,12 +111,12 @@ func TestBulkStrings(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			result := pkg.SerializeBulkStrings(tt.input)
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.SerializeBulkStrings(tc.input)
 
-			if result != tt.expected {
-				t.Errorf("got %s, want %s", result, tt.expected)
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
 			}
 		})
 	}
@@ -121,12 +150,12 @@ func TestArrays(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			result := pkg.SerializeArrays(tt.input)
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result := pkg.SerializeArrays(tc.input)
 
-			if result != tt.expected {
-				t.Errorf("got %s, want %s", result, tt.expected)
+			if result != tc.expected {
+				t.Errorf("got %s, want %s", result, tc.expected)
 			}
 		})
 	}

--- a/pkg/serializer_test.go
+++ b/pkg/serializer_test.go
@@ -149,6 +149,11 @@ func TestArrays(t *testing.T) {
 			expected:    "*3\r\n:1\r\n:2\r\n:3\r\n",
 		},
 		{
+			description: "returns mixed element array",
+			input:       []interface{}{1, "2", 3},
+			expected:    "*5\r\n:1\r\n:2\r\n:3\r\n:4\r\n$5\r\nhello\r\n",
+		},
+		{
 			description: "returns unsupported type",
 			input:       map[string]int{"a": 1},
 			expected:    "",


### PR DESCRIPTION
### Summary
Implementing the protocol defined here - https://redis.io/docs/latest/develop/reference/protocol-spec/

The idea here is to serialize and deserialize messages sent to the server. I'm only implementing serialisation for the RESP2 protocol.

### Notes
In RESP, the first byte determines the data type:
- For Simple Strings, the first byte of the reply is `"+"`
- For Errors, the first byte of the reply is `"-"`
- For Integers, the first byte of the reply is `":"`
- For Bulk Strings, the first byte of the reply is `"$"`
- For Arrays, the first byte of the reply is `"*"`
